### PR TITLE
fixed #11 and #12 examples

### DIFF
--- a/join.sql
+++ b/join.sql
@@ -110,7 +110,7 @@ For every match involving 'POL', show the matchid, date and the number of goals 
 SELECT matchid, mdate, COUNT(player) AS goals
 FROM game
   JOIN goal ON (matchid=id AND (team1 = 'POL' OR team2 = 'POL'))
-GROUP BY matchid
+GROUP BY matchid, mdate
 
 --#12
 /*
@@ -119,7 +119,7 @@ For every match where 'GER' scored, show matchid, match date and the number of g
 SELECT id, mdate, COUNT(player)
 FROM game
   JOIN goal ON (id=matchid AND (team1 = 'GER' OR team2 = 'GER') AND teamid='GER')
-GROUP BY id
+GROUP BY id, mdate
 
 --#13
 /*


### PR DESCRIPTION
If the last string is "GROUP BY id" (for example #12) I get an error: 'gisq.game.mdate' isn't in GROUP BY
Then you add mdate and all runs just fine, same goes for example #11.