### PR TITLE
Changing to single quotes for Physics in q8

### DIFF
--- a/select-from-nobel.sql
+++ b/select-from-nobel.sql
@@ -68,7 +68,7 @@ Show the Physics winners for 1980 together with the Chemistry winners for 1984.
 */
 SELECT *
 FROM nobel
-WHERE (subject = "Physics" AND yr = '1980') OR (subject = 'Chemistry' AND yr = 1984)
+WHERE (subject = 'Physics' AND yr = '1980') OR (subject = 'Chemistry' AND yr = 1984)
 
 --#9
 /*


### PR DESCRIPTION
SQL doesn't use generally double quotes.